### PR TITLE
Update default.txt

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
-pytz>dev
+pytz
 billiard>=3.5.0.2,<3.6.0
 kombu>=4.2.0,<5.0


### PR DESCRIPTION
pytz>dev is not valid since pip 23, so fixing it.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
